### PR TITLE
Added format on save feature.

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -10,21 +10,21 @@
         "children":
         [
           {
-            "caption": "GoSublime",
+            "caption": "SublimeLinter-standard",
             "children":
             [
               {
                 "caption": "Settings – Default",
                 "command": "open_file",
                 "args": {
-                  "file": "${packages}/SublimeLinter-contrib-standard/SublimeLinter-contrib-standard.sublime-settings"
+                  "file": "${packages}/SublimeLinter-contrib-standard/SL-contrib-standard.sublime-settings"
                 }
               },
               {
                 "caption": "Settings – User",
                 "command": "open_file",
                 "args": {
-                  "file": "${packages}/User/SublimeLinter-contrib-standard.sublime-settings"
+                  "file": "${packages}/User/SL-contrib-standard.sublime-settings"
                 }
               },
               { "caption": "-" },
@@ -57,7 +57,7 @@
                 "caption": "Read Me",
                 "command": "open_file",
                 "args": {
-                  "file": "${packages}/GoSublime/README.md"
+                  "file": "${packages}/SublimeLinter-contrib-standard/README.md"
                 }
               },
               { "caption": "-" },
@@ -65,8 +65,14 @@
                 "caption": "License (MIT)",
                 "command": "open_file",
                 "args": {
-                  "file": "${packages}/GoSublime/LICENSE"
+                  "file": "${packages}/SublimeLinter-contrib-standard/LICENSE"
                 }
+              },
+              { "caption": "-" },
+              {
+                  "command": "toggle_standard_format",
+                  "caption": "Format On Save",
+                  "checkbox": true
               }
             ]
           }

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,77 @@
+[
+  {
+    "caption": "Preferences",
+    "id": "preferences",
+    "children":
+    [
+      {
+        "caption": "Package Settings",
+        "id": "package-settings",
+        "children":
+        [
+          {
+            "caption": "GoSublime",
+            "children":
+            [
+              {
+                "caption": "Settings – Default",
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/SublimeLinter-contrib-standard/SublimeLinter-contrib-standard.sublime-settings"
+                }
+              },
+              {
+                "caption": "Settings – User",
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/User/SublimeLinter-contrib-standard.sublime-settings"
+                }
+              },
+              { "caption": "-" },
+              {
+                "caption": "Key Bindings – Default",
+                "platform": "Linux",
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/SublimeLinter-contrib-standard/Default (Linux).sublime-keymap"
+                }
+              },
+              {
+                "caption": "Key Bindings – Default",
+                "platform": "Windows",
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/SublimeLinter-contrib-standard/Default (Windows).sublime-keymap"
+                }
+              },
+              {
+                "caption": "Key Bindings – Default",
+                "platform": "OSX",
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/SublimeLinter-contrib-standard/Default (OSX).sublime-keymap"
+                }
+              },
+              { "caption": "-" },
+              {
+                "caption": "Read Me",
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/GoSublime/README.md"
+                }
+              },
+              { "caption": "-" },
+              {
+                "caption": "License (MIT)",
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/GoSublime/LICENSE"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/SL-contrib-standard.sublime-settings
+++ b/SL-contrib-standard.sublime-settings
@@ -1,0 +1,6 @@
+{
+    // format on save
+    "format_on_save": false,
+
+}
+

--- a/SublimeLinter-contrib-standard.sublime-settings
+++ b/SublimeLinter-contrib-standard.sublime-settings
@@ -1,5 +1,0 @@
-{
-    // format on save
-    "format_on_save": true,
-
-}

--- a/SublimeLinter-contrib-standard.sublime-settings
+++ b/SublimeLinter-contrib-standard.sublime-settings
@@ -1,0 +1,5 @@
+{
+    // format on save
+    "format_on_save": true,
+
+}

--- a/format.py
+++ b/format.py
@@ -13,7 +13,35 @@
 import sublime
 import sublime_plugin
 from SublimeLinter.lint import util
+import os
 
+settings = None
+
+
+def plugin_loaded():
+    global settings
+    settings = sublime.load_settings(
+        "SublimeLinter-contrib-standard.sublime-settings")
+
+def is_javascript(view):
+    """Checks if the current view is javascript or not.  Used pre_save event"""
+    # Check the file extension
+    name = view.file_name()
+    excludes = set(settings.get('excludes', []))
+    includes = set(settings.get('includes', ['js']))
+    if name and os.path.splitext(name)[1][1:] in includes - excludes:
+        return True
+    # If it has no name (?) or it's not a JS, check the syntax
+    syntax = view.settings().get("syntax")
+    if syntax and "javascript" in syntax.split("/")[-1].lower():
+        return True
+    return False
+
+class StandardFormatEventListener(sublime_plugin.EventListener):
+
+    def on_pre_save(self, view):
+        if settings.get("format_on_save") and is_javascript(view):
+            view.run_command("standard_format")
 
 class StandardFormatCommand(sublime_plugin.TextCommand):
 

--- a/format.py
+++ b/format.py
@@ -23,6 +23,7 @@ def plugin_loaded():
     settings = sublime.load_settings(
         "SublimeLinter-contrib-standard.sublime-settings")
 
+
 def is_javascript(view):
     """Checks if the current view is javascript or not.  Used pre_save event"""
     # Check the file extension
@@ -37,11 +38,13 @@ def is_javascript(view):
         return True
     return False
 
+
 class StandardFormatEventListener(sublime_plugin.EventListener):
 
     def on_pre_save(self, view):
         if settings.get("format_on_save") and is_javascript(view):
             view.run_command("standard_format")
+
 
 class StandardFormatCommand(sublime_plugin.TextCommand):
 
@@ -73,11 +76,11 @@ class StandardFormatCommand(sublime_plugin.TextCommand):
         cmd.append("--format")
 
         if not region.empty():
-                s = v.substr(region)
-                s = util.communicate(cmd, code=s)
-                if len(s) > 0:
-                    v.replace(edit, region, s)
-                else:
-                    args = cmd, code = s, output_stream = util.STREAM_STDERR
-                    error = util.communicate(args)
-                    sublime.error_message(error)
+            s = v.substr(region)
+            s = util.communicate(cmd, code=s)
+            if len(s) > 0:
+                v.replace(edit, region, s)
+            else:
+                args = cmd, code = s, output_stream = util.STREAM_STDERR
+                error = util.communicate(args)
+                sublime.error_message(error)

--- a/format.py
+++ b/format.py
@@ -15,13 +15,14 @@ import sublime_plugin
 from SublimeLinter.lint import util
 import os
 
+SETTINGS_FILE = "SL-contrib-standard.sublime-settings"
+
 settings = None
 
 
 def plugin_loaded():
     global settings
-    settings = sublime.load_settings(
-        "SublimeLinter-contrib-standard.sublime-settings")
+    settings = sublime.load_settings(SETTINGS_FILE)
 
 
 def is_javascript(view):
@@ -44,6 +45,19 @@ class StandardFormatEventListener(sublime_plugin.EventListener):
     def on_pre_save(self, view):
         if settings.get("format_on_save") and is_javascript(view):
             view.run_command("standard_format")
+
+
+class ToggleStandardFormatCommand(sublime_plugin.TextCommand):
+
+    def run(self, edit):
+        if settings.get('format_on_save', False):
+            settings.set('format_on_save', False)
+        else:
+            settings.set('format_on_save', True)
+        sublime.save_settings(SETTINGS_FILE)
+
+    def is_checked(self):
+        return settings.get('format_on_save', False)
 
 
 class StandardFormatCommand(sublime_plugin.TextCommand):

--- a/standard_format.sublime-commands
+++ b/standard_format.sublime-commands
@@ -1,3 +1,20 @@
 [
-    { "caption": "Format: JavaScript Standard Style", "command": "standard_format" }
+    { 
+      "caption": "SublimeLinter-standard: Format current file", 
+      "command": "standard_format" 
+    },
+    {
+      "caption": "SublimeLinter-standard: Toggle format on save",
+      "command": "toggle_standard_format"
+    },
+    {
+        "caption": "SublimeLinter-standard: Settings - Default",
+        "command": "open_file",
+        "args": {"file": "${packages}/SublimeLinter-contrib-standard/SL-contrib-standard.sublime-settings"}
+    },
+    {
+        "caption": "SublimeLinter-standard: Settings - User",
+        "command": "open_file",
+        "args": {"file": "${packages}/User/SL-contrib-standard.sublime-settings"}
+    }
 ]


### PR DESCRIPTION
Please don't merge yet.  A few questions:
- Is there a way to ask SublimeLint if the active file is javascript?  For now, I just reused the `is_javascript()` function.
- Performance is really bad at the moment.  I had to do naive PATH editing, but I was getting much better performance using `subprocess` and `standard-format`.  I'm not sure what the culprit is yet. (see https://github.com/bcomnes/sublime-standard-format/blob/master/standard-format.py#L44)
- How should I allow people to specify which file extensions to include/exclude beyond the defaults?

Other things todo here:
- [x] Set up command palette option that toggles this on and off.
- [x] Set the default state to not automatically format on save.
- [ ] Fix the style errors
