### PR TITLE
Removed format command reference

### DIFF
--- a/messages/3.0.1.txt
+++ b/messages/3.0.1.txt
@@ -1,0 +1,3 @@
+SublimeLinter-contrib-standard
+-------------------------------
+- Removed missing format command from command menu

--- a/standard_format.sublime-commands
+++ b/standard_format.sublime-commands
@@ -1,3 +1,0 @@
-[
-    { "caption": "Format: JavaScript Standard Style", "command": "standard_format" }
-]


### PR DESCRIPTION
Looks like the format command from the ctl-p menu never was removed.
