### PR TITLE
Adjust linter plugin to match sublime linter v4 API

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -11,39 +11,17 @@
 """This module exports the Standard plugin class."""
 
 from SublimeLinter.lint import NodeLinter
-import re
 
 
 class Standard(NodeLinter):
     """Provides an interface to standard."""
 
-    syntax = ('javascript', 'html', 'javascriptnext', 'javascript 6to5', 'javascript (babel)')
     cmd = 'standard --stdin --verbose'
-    version_args = '--version'
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 3.7.2'
+    name = 'Standard'
     regex = r'^\s.+:(?P<line>\d+):(?P<col>\d+):(?P<message>.+)'
-    selectors = {
-        'html': 'source.js.embedded.html'
-    }
 
-    html_pattern = re.compile(r'(^.*\n)\s+$', re.DOTALL)
-
-    npm_name = 'standard'
     defaults = {
         'enable_if_dependency': True,
-        'disable_if_not_dependency': False
+        'disable_if_not_dependency': False,
+        'selector': 'source.js, source.jsx'
     }
-
-    def run(self, cmd, code):
-        """
-        If HTML syntax and the last line is just whitespace then remove it.
-
-        Its probably just space before closing.
-        script tag
-        """
-        if code and self.syntax == 'html':
-            match = self.html_pattern.match(code)
-            if match:
-                code = match.group(1)
-        return super(Standard, self).run(cmd, code)


### PR DESCRIPTION
When run against Sublime Linter >= 4.12.0 SublimeLinter-contrib-standard stops working due to API deprecations: #38 

This adjusts the plugin to use the expected v4 attributes. I can use this locally against plain JS, JS embedded in Markdown as well as in HTML and JSX.

---

Probably also related to #36 and #31 